### PR TITLE
Initialize React/Node monorepo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# etudebook
+# Etudebook
+
+Monorepo for the piano practice web service.
+
+## Packages
+
+- `frontend` - React + TypeScript client
+- `backend` - Node.js Express server
+
+Use npm workspaces to manage packages.
+
+### Common Commands
+
+- `npm run dev:frontend` - start the frontend dev server
+- `npm run dev:backend` - start the backend server
+
+Install dependencies in each workspace with `npm install`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# Backend
+
+Simple Express server for the piano practice app.
+
+## Scripts
+
+- `npm start` - start the server on port 3001 (or `PORT` env).
+
+## Dependencies
+
+- express
+
+Install packages with `npm install`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,0 +1,5 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3001;
+app.get('/', (req, res) => { res.send('Hello from backend'); });
+app.listen(PORT, () => console.log(`Backend running on port ${PORT}`));

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,10 @@
+# Frontend
+
+React + TypeScript setup built with webpack.
+
+## Scripts
+
+- `npm start` - start dev server on port 3000
+- `npm run build` - build production bundle
+
+Install packages with `npm install` before running scripts.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.6",
+    "@types/react-dom": "^18.2.4",
+    "html-webpack-plugin": "^5.5.0",
+    "ts-loader": "^9.5.0",
+    "typescript": "^5.2.2",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Piano Practice</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const App: React.FC = () => {
+  return <div>Hello from React frontend</div>;
+};
+
+export default App;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,30 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.tsx',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+    clean: true,
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  plugins: [
+    new HtmlWebpackPlugin({ template: 'public/index.html' }),
+  ],
+  devServer: {
+    static: './dist',
+    port: 3000,
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "etudebook",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev:frontend": "npm start --workspace frontend",
+    "dev:backend": "npm start --workspace backend"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "workspaces": [
+    "frontend",
+    "backend"
+  ]
+}


### PR DESCRIPTION
## Summary
- set up root workspace with npm workspaces
- add React TypeScript frontend using webpack
- add Express backend server
- provide README docs for root, frontend and backend

## Testing
- `node --version`
- `npm --version`
